### PR TITLE
Removing the DB struct which had all db accessing methods related to it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@ This Project uses [SQLx](https://github.com/launchbadge/sqlx) for database inter
 
 There are many ways to get a local Postgres DB instance, and I recommend using a [Postgres Docker image](https://hub.docker.com/_/postgres). 
 
-```bash
-```
-
 ### Running dev
 
 This project uses [auto reloading](https://actix.rs/docs/autoreload/) in dev.

--- a/src/graphql/context.rs
+++ b/src/graphql/context.rs
@@ -1,9 +1,8 @@
 use std::sync::Arc;
 
-use crate::services::db::DB;
 use futures::lock::Mutex;
 use juniper;
-use sqlx::PgPool;
+use sqlx::{PgPool};
 
 use crate::graphql::loaders::org_loader::{get_org_loader, OrgLoader};
 use crate::graphql::loaders::structure_loader::{get_structure_loader, StructureLoader};
@@ -14,8 +13,6 @@ pub struct GQLContext {
   // Auth related. Might be nice to have the full token here.
   pub auth0_user_id: String,
 
-  pub db: DB,
-
   // Dataloaders
   pub org_loader: OrgLoader,
 
@@ -24,7 +21,7 @@ pub struct GQLContext {
   pub auth0_api: Arc<Arc<Mutex<Auth0Service>>>,
 }
 
-impl juniper::Context for GQLContext {}
+impl<'c> juniper::Context for GQLContext {}
 
 impl GQLContext {
   pub fn new(
@@ -32,14 +29,11 @@ impl GQLContext {
     auth0_user_id: String,
     auth0_api: Arc<Arc<Mutex<Auth0Service>>>,
   ) -> Self {
-    let db = DB::new(pool.clone());
-
     GQLContext {
       pool: pool.clone(),
       auth0_user_id,
-      db: db.clone(),
-      org_loader: get_org_loader(db.clone()),
-      structure_loader: get_structure_loader(db.clone()),
+      org_loader: get_org_loader(pool.clone()),
+      structure_loader: get_structure_loader(pool.clone()),
       auth0_api,
     }
   }

--- a/src/graphql/schema/blocks/basic_table_block.rs
+++ b/src/graphql/schema/blocks/basic_table_block.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 use crate::graphql::context::GQLContext;
 use crate::graphql::schema::block::{Block, BlockTypes, NewBlock};
 use crate::graphql::schema::Mutation;
+use crate::services::db::block_service::create_block;
 
 #[derive(GraphQLObject, Debug, Serialize, Deserialize)]
 pub struct BasicTableBlock {
@@ -52,9 +53,7 @@ impl Mutation {
   ) -> FieldResult<Block> {
     let new_block: NewBlock = new_basic_table_block.into();
 
-    ctx
-      .db
-      .create_block(&ctx.auth0_user_id, new_block.into())
+      create_block(&ctx.pool, &ctx.auth0_user_id, new_block.into())
       .await
       .map(|db_block| db_block.into())
       .map_err(FieldError::from)

--- a/src/graphql/schema/cell.rs
+++ b/src/graphql/schema/cell.rs
@@ -10,7 +10,7 @@ use strum_macros::EnumString;
 use super::Query;
 
 use crate::graphql::context::GQLContext;
-use crate::services::db::cell_service::DBCell;
+use crate::services::db::cell_service::{DBCell, get_cell};
 use uuid::Uuid;
 
 #[derive(Debug, GraphQLUnion, Serialize, Deserialize)]
@@ -95,9 +95,7 @@ pub struct EmptyCell {
 
 impl Query {
   pub async fn cell_impl(ctx: &GQLContext, cell_id: Uuid) -> FieldResult<Cell> {
-    ctx
-      .db
-      .get_cell(cell_id)
+      get_cell(&ctx.pool, cell_id)
       .await
       .map(|db_cell| db_cell.into())
       .map_err(FieldError::from)

--- a/src/graphql/schema/dimension.rs
+++ b/src/graphql/schema/dimension.rs
@@ -1,4 +1,4 @@
-use crate::services::db::dimension_service::DBNewDimension;
+use crate::services::db::dimension_service::{DBNewDimension, get_dimensions, create_dimensions};
 use crate::{graphql::context::GQLContext, services::db::dimension_service::DBDimension};
 use chrono::{DateTime, Utc};
 use juniper::{FieldError, FieldResult, GraphQLEnum, GraphQLInputObject, GraphQLObject};
@@ -70,9 +70,8 @@ pub struct NewDimension {
 
 impl Query {
   pub async fn dimensions_impl(ctx: &GQLContext, portal_id: Uuid) -> FieldResult<Vec<Dimension>> {
-    ctx
-      .db
-      .get_dimensions(portal_id)
+
+      get_dimensions(&ctx.pool, portal_id)
       .await
       .map(|dimensions| {
         dimensions
@@ -94,9 +93,7 @@ impl Mutation {
       .map(|db_dim| db_dim.into())
       .collect::<Vec<DBNewDimension>>();
 
-    ctx
-      .db
-      .create_dimensions(&ctx.auth0_user_id, db_dims)
+      create_dimensions(&ctx.pool, &ctx.auth0_user_id, db_dims)
       .await
       .map(|db_dimensions| {
         db_dimensions

--- a/src/graphql/schema/mod.rs
+++ b/src/graphql/schema/mod.rs
@@ -151,6 +151,10 @@ impl Mutation {
     Mutation::create_portal_impl(ctx, new_portal).await
   }
 
+  async fn delete_portal(ctx: &GQLContext, portal_id: Uuid) -> FieldResult<i32> {
+    Mutation::delete_portal_impl(ctx, portal_id).await
+  }
+
   // PortalView
 
   // the space in 'portal_view' is needed so that it shows up as "createPortalView" in GQL Schema
@@ -170,6 +174,14 @@ impl Mutation {
   // async fn create_block(ctx: &GQLContext, new_block: NewBlock) -> FieldResult<Block> {
   //   Mutation::create_block(ctx, new_block).await
   // }
+
+  async fn delete_block(ctx: &GQLContext, block_id: Uuid) -> FieldResult<i32> {
+    Mutation::delete_block(ctx, block_id).await
+  }
+
+  async fn delete_blocks(ctx: &GQLContext, block_ids: Vec<Uuid>) -> FieldResult<i32> {
+    Mutation::delete_blocks(ctx, block_ids).await
+  }
 
   async fn create_basic_table(ctx: &GQLContext, new_basic_table_block: NewBasicTableBlock) -> FieldResult<Block> {
     Mutation::create_basic_table_impl(ctx, new_basic_table_block).await

--- a/src/graphql/schema/portalview.rs
+++ b/src/graphql/schema/portalview.rs
@@ -8,6 +8,7 @@ use crate::graphql::context::GQLContext;
 
 use crate::graphql::schema::structure::Structure;
 use crate::services::db::portalview_service::DBPortalView;
+use crate::services::db::portalview_service::{get_portal_views, create_portalview};
 
 // Portal View
 
@@ -62,7 +63,9 @@ impl PortalView {
   }
 
   fn structure_id(&self) -> Uuid {
-    self.structure_id.clone()
+    self
+      .structure_id
+      .clone()
   }
 
   pub async fn structure(&self, context: &GQLContext) -> Structure {
@@ -121,9 +124,7 @@ pub struct NewPortalView {
 
 impl Query {
   pub async fn portalviews_impl(ctx: &GQLContext, portal_id: Uuid) -> FieldResult<Vec<PortalView>> {
-    ctx
-      .db
-      .get_portal_views(portal_id)
+    get_portal_views(&ctx.pool, portal_id)
       .await
       .map(|db_portalviews| {
         db_portalviews
@@ -140,9 +141,7 @@ impl Mutation {
     ctx: &GQLContext,
     new_portalview: NewPortalView,
   ) -> FieldResult<PortalView> {
-    ctx
-      .db
-      .create_portalview(&ctx.auth0_user_id, new_portalview.into())
+    create_portalview(&ctx.pool, &ctx.auth0_user_id, new_portalview.into())
       .await
       .map(|db_portalview| db_portalview.into())
       .map_err(FieldError::from)

--- a/src/graphql/schema/role.rs
+++ b/src/graphql/schema/role.rs
@@ -7,7 +7,7 @@ use strum_macros::{EnumString, ToString};
 use uuid::Uuid;
 
 use crate::graphql::context::GQLContext;
-use crate::services::db::role_service::{DBNewRole, DBRole};
+use crate::services::db::role_service::{DBNewRole, DBRole, get_role, create_role};
 
 use super::Query;
 use super::Mutation;
@@ -149,9 +149,7 @@ impl From<DBNewRole> for NewRole {
 
 impl Query {
   pub async fn role_impl(ctx: &GQLContext, role_id: Uuid) -> FieldResult<Role> {
-    ctx
-      .db
-      .get_role(role_id)
+      get_role(&ctx.pool, role_id)
       .await
       .map(|db_role| db_role.into())
       .map_err(FieldError::from)
@@ -160,9 +158,7 @@ impl Query {
 
 impl Mutation {
   pub async fn create_role_impl(ctx: &GQLContext, new_role: NewRole) -> FieldResult<Role> {
-    ctx
-      .db
-      .create_role(&ctx.auth0_user_id, new_role.into())
+      create_role(&ctx.pool, &ctx.auth0_user_id, new_role.into())
       .await
       .map(|role| -> Role { role.into() })
       .map_err(FieldError::from)

--- a/src/graphql/schema/structure.rs
+++ b/src/graphql/schema/structure.rs
@@ -12,6 +12,7 @@ use std::str::FromStr;
 use strum_macros::{Display, EnumString};
 use uuid::Uuid;
 
+use crate::services::db::structure_service::{get_structure, get_structures, update_structure};
 use crate::{graphql::context::GQLContext, services::db::structure_service::DBStructure};
 
 use super::Mutation;
@@ -224,9 +225,7 @@ pub struct EmptyStructure {
 
 impl Query {
   pub async fn structure_impl(ctx: &GQLContext, structure_id: Uuid) -> FieldResult<Structure> {
-    ctx
-      .db
-      .get_structure(structure_id)
+    get_structure(&ctx.pool, structure_id)
       .await
       .map(|db_structure| db_structure.into())
       .map_err(FieldError::from)
@@ -236,9 +235,7 @@ impl Query {
     ctx: &GQLContext,
     structure_ids: Vec<Uuid>,
   ) -> FieldResult<Vec<Structure>> {
-    ctx
-      .db
-      .get_structures(&structure_ids)
+    get_structures(&ctx.pool, &structure_ids)
       .await
       .map(|db_structures| {
         db_structures
@@ -253,11 +250,9 @@ impl Query {
 impl Mutation {
   pub async fn update_structure_impl(
     ctx: &GQLContext,
-    update_structure: UpdateStructure,
+    updated_structure: UpdateStructure,
   ) -> FieldResult<Structure> {
-    ctx
-      .db
-      .update_structure(&ctx.auth0_user_id, update_structure.into())
+    update_structure(&ctx.pool, &ctx.auth0_user_id, updated_structure.into())
       .await
       .map(|db_structure| db_structure.into())
       .map_err(FieldError::from)

--- a/src/services/db/block_service.rs
+++ b/src/services/db/block_service.rs
@@ -1,10 +1,9 @@
 use crate::graphql::schema::block::NewBlock;
 
-use super::DB;
-
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use serde_json;
+use sqlx::{Executor, Postgres};
 use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -52,54 +51,85 @@ pub struct DBNewBlock {
 
 impl From<NewBlock> for DBNewBlock {
   fn from(new_block: NewBlock) -> Self {
-
     DBNewBlock {
-        block_type: new_block.block_type.to_string(),
-        portal_id: new_block.portal_id,
-        portal_view_id: new_block.portal_view_id,
-        egress: new_block.egress,
-        block_data: new_block.block_data,
+      block_type: new_block
+        .block_type
+        .to_string(),
+      portal_id: new_block.portal_id,
+      portal_view_id: new_block.portal_view_id,
+      egress: new_block.egress,
+      block_data: new_block.block_data,
     }
   }
 }
 
-impl DB {
-  pub async fn get_block(&self, block_id: Uuid) -> Result<DBBlock> {
-    sqlx::query_as!(DBBlock, "select * from blocks where id  = $1", block_id)
-      .fetch_one(&self.pool)
-      .await
-      .map_err(anyhow::Error::from)
-  }
-
-  pub async fn get_blocks(&self, portal_id: Uuid) -> Result<Vec<DBBlock>> {
-    sqlx::query_as!(
-      DBBlock,
-      "select * from blocks where portal_id = $1",
-      portal_id
-    )
-    .fetch_all(&self.pool)
+pub async fn get_block<'e>(
+  pool: impl Executor<'e, Database = Postgres>,
+  block_id: Uuid,
+) -> Result<DBBlock> {
+  sqlx::query_as!(DBBlock, "select * from blocks where id  = $1", block_id)
+    .fetch_one(pool)
     .await
     .map_err(anyhow::Error::from)
-  }
+}
 
-  pub async fn create_block(&self, auth0_user_id: &str, new_block: DBNewBlock) -> Result<DBBlock> {
-    sqlx::query_as!(
-      DBBlock,
-      r#"
-      with _user as (select * from users where auth0id = $1)
-      insert into blocks (block_type, portal_id, portal_view_id, egress, block_data, created_by, updated_by)
-      values ($2, $3, $4, $5, $6, (select id from _user), (select id from _user))
-      returning *;
-      "#,
-      auth0_user_id,
-      new_block.block_type,
-      new_block.portal_id,
-      new_block.portal_view_id,
-      new_block.egress,
-      new_block.block_data,
-    )
-    .fetch_one(&self.pool)
+pub async fn get_blocks<'e>(
+  pool: impl Executor<'e, Database = Postgres>,
+  portal_id: Uuid,
+) -> Result<Vec<DBBlock>> {
+  sqlx::query_as!(
+    DBBlock,
+    "select * from blocks where portal_id = $1",
+    portal_id
+  )
+  .fetch_all(pool)
+  .await
+  .map_err(anyhow::Error::from)
+}
+
+pub async fn create_block<'e>(
+  pool: impl Executor<'e, Database = Postgres>,
+  auth0_user_id: &str,
+  new_block: DBNewBlock,
+) -> Result<DBBlock> {
+  sqlx::query_as!(
+    DBBlock,
+    r#"
+    with _user as (select * from users where auth0id = $1)
+    insert into blocks (block_type, portal_id, portal_view_id, egress, block_data, created_by, updated_by)
+    values ($2, $3, $4, $5, $6, (select id from _user), (select id from _user))
+    returning *;
+    "#,
+    auth0_user_id,
+    new_block.block_type,
+    new_block.portal_id,
+    new_block.portal_view_id,
+    new_block.egress,
+    new_block.block_data,
+  )
+  .fetch_one(pool)
+  .await
+  .map_err(anyhow::Error::from)
+}
+
+pub async fn delete_block<'e>(
+  pool: impl Executor<'e, Database = Postgres>,
+  block_id: Uuid,
+) -> Result<i32> {
+  sqlx::query!("delete from blocks where id = $1", block_id)
+    .execute(pool)
     .await
+    .map(|qr| qr.rows_affected() as i32)
     .map_err(anyhow::Error::from)
-  }
+}
+
+pub async fn delete_blocks<'e>(
+  pool: impl Executor<'e, Database = Postgres>,
+  block_ids: Vec<Uuid>,
+) -> Result<i32> {
+  sqlx::query!("delete from blocks where id = any($1)", &block_ids)
+    .execute(pool)
+    .await
+    .map(|qr| qr.rows_affected() as i32)
+    .map_err(anyhow::Error::from)
 }

--- a/src/services/db/cell_service.rs
+++ b/src/services/db/cell_service.rs
@@ -1,8 +1,7 @@
-use super::DB;
-
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use serde_json;
+use sqlx::{Executor, Postgres};
 use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -33,11 +32,9 @@ pub struct DBCell {
   pub updated_by: Uuid,
 }
 
-impl DB {
-  pub async fn get_cell(&self, cell_id: Uuid) -> Result<DBCell> {
-    sqlx::query_as!(DBCell, "select * from cells where id = $1", cell_id)
-      .fetch_one(&self.pool)
-      .await
-      .map_err(anyhow::Error::from)
-  }
+pub async fn get_cell<'e>(pool: impl Executor<'e, Database = Postgres>, cell_id: Uuid) -> Result<DBCell> {
+  sqlx::query_as!(DBCell, "select * from cells where id = $1", cell_id)
+    .fetch_one(pool)
+    .await
+    .map_err(anyhow::Error::from)
 }

--- a/src/services/db/db.rs
+++ b/src/services/db/db.rs
@@ -1,12 +1,33 @@
-use sqlx::{PgPool};
+// use futures::Future;
+// use sqlx::{PgPool, Postgres, Transaction};
 
-#[derive(Debug, Clone)]
-pub struct DB {
-  pub pool: PgPool,
-}
+// use anyhow::Result;
 
-impl DB {
-  pub fn new(pool: PgPool) -> Self {
-    DB { pool }
-  }
-}
+// // #[derive(Debug, Clone)]
+// // pub struct DB<'db, Ex = PgPool>
+// // where
+// //   Ex: Executor<'db>,
+// // {
+// //   pub pool: Ex,
+// // }
+
+// // impl<'db, Ex> DB<'db, Ex> {
+// //   pub fn new(pool: Ex) -> Self {
+// //     DB { pool }
+// //   }
+
+// // }
+
+// pub async fn transaction<'c, R, Fut: Future<Output = Result<R>>>(
+//   pool: PgPool,
+//   f: impl Fn(Transaction<'c, Postgres>) -> Fut,
+// ) -> Result<R> {
+//   // let tx: Transaction<'c, Postgres> = pool.begin().await?;
+//   let tx = pool.begin().await?;
+
+//   let r = f(tx).await;
+
+//   // tx.commit().await?;
+
+//   Ok(r)
+// }

--- a/src/services/db/portal_service.rs
+++ b/src/services/db/portal_service.rs
@@ -1,10 +1,9 @@
-use crate::graphql::schema::portal::NewPortal;
-
-use super::DB;
-
 use anyhow::Result;
 use chrono::{DateTime, Utc};
+use sqlx::{Executor, PgPool, Postgres};
 use uuid::Uuid;
+
+use crate::graphql::schema::portal::NewPortal;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DBPortal {
@@ -53,49 +52,57 @@ impl From<NewPortal> for DBNewPortal {
   }
 }
 
-impl DB {
-  pub async fn get_portal(&self, portal_id: Uuid) -> Result<DBPortal> {
-    sqlx::query_as!(DBPortal, "select * from portals where id = $1", portal_id)
-      .fetch_one(&self.pool)
-      .await
-      .map_err(anyhow::Error::from)
-  }
-
-  pub async fn get_portals(&self, portal_ids: Vec<Uuid>) -> Result<Vec<DBPortal>> {
-    sqlx::query_as!(
-      DBPortal,
-      "select * from portals where id = any($1)",
-      &portal_ids
-    )
-    .fetch_all(&self.pool)
+pub async fn get_portal<'e>(
+  pool: impl Executor<'e, Database = Postgres>,
+  portal_id: Uuid,
+) -> Result<DBPortal> {
+  sqlx::query_as!(DBPortal, "select * from portals where id = $1", portal_id)
+    .fetch_one(pool)
     .await
     .map_err(anyhow::Error::from)
-  }
+}
 
-  pub async fn get_auth0_user_portals(&self, auth0_user_id: &str) -> Result<Vec<DBPortal>> {
-    sqlx::query_as!(
-      DBPortal,
-      r#"
-      with _user as (select * from users where auth0id = $1)
-      select * from portals where
-      (select id from _user) = any(owner_ids) or
-      (select id from _user) = any(vendor_ids);
-      "#,
-      auth0_user_id
-    )
-    .fetch_all(&self.pool)
-    .await
-    .map_err(anyhow::Error::from)
-  }
+pub async fn get_portals<'e>(
+  pool: impl Executor<'e, Database = Postgres>,
+  portal_ids: Vec<Uuid>,
+) -> Result<Vec<DBPortal>> {
+  sqlx::query_as!(
+    DBPortal,
+    "select * from portals where id = any($1)",
+    &portal_ids
+  )
+  .fetch_all(pool)
+  .await
+  .map_err(anyhow::Error::from)
+}
 
-  pub async fn create_portal(
-    &self,
-    auth0_user_id: &str,
-    new_portal: DBNewPortal,
-  ) -> Result<DBPortal> {
-    sqlx::query_as!(
-      DBPortal,
-      r#"
+pub async fn get_auth0_user_portals<'e>(
+  pool: impl Executor<'e, Database = Postgres>,
+  auth0_user_id: &str,
+) -> Result<Vec<DBPortal>> {
+  sqlx::query_as!(
+    DBPortal,
+    r#"
+    with _user as (select * from users where auth0id = $1)
+    select * from portals where
+    (select id from _user) = any(owner_ids) or
+    (select id from _user) = any(vendor_ids);
+    "#,
+    auth0_user_id
+  )
+  .fetch_all(pool)
+  .await
+  .map_err(anyhow::Error::from)
+}
+
+pub async fn create_portal<'e>(
+  pool: impl Executor<'e, Database = Postgres>,
+  auth0_user_id: &str,
+  new_portal: DBNewPortal,
+) -> Result<DBPortal> {
+  sqlx::query_as!(
+    DBPortal,
+    r#"
       with _user as (select * from users where auth0id = $1)
       insert into portals (
         name,
@@ -113,14 +120,25 @@ impl DB {
         (select id from _user)
       ) returning *
       "#,
-      auth0_user_id,
-      new_portal.name,
-      new_portal.org_id,
-      &new_portal.owner_ids,
-      &new_portal.vendor_ids
-    )
-    .fetch_one(&self.pool)
-    .await
-    .map_err(anyhow::Error::from)
-  }
+    auth0_user_id,
+    new_portal.name,
+    new_portal.org_id,
+    &new_portal.owner_ids,
+    &new_portal.vendor_ids
+  )
+  .fetch_one(pool)
+  .await
+  .map_err(anyhow::Error::from)
+}
+
+pub async fn delete_portal<'e>(pool: PgPool, portal_id: Uuid) -> Result<i32> {
+  let mut tx = pool.begin().await?;
+
+  let portal = get_portal(&mut tx, portal_id).await?;
+
+  dbg!(portal);
+
+  tx.commit().await?;
+
+  Ok(1)
 }


### PR DESCRIPTION
Now db methods are free functions that accept an `Executor<'a, Database = Postgres>` type, which both database pools, and transaction structs implement. This should allow db functions to be used in a more composed fashion. Check out the `delete_portal` function in the portal_service for a super basic example of creating a transaction.

This is a lot of code changed, but most of it is just refactoring.