### PR TITLE
Supports adding Integration to `VendorText` on the web client

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -35,8 +35,16 @@ pub struct OAuth {
   pub auth_url: String,
   pub token_url: String,
   pub auth_redirect_url: String,
-  pub drive_scope: String,
-  pub sheets_scope: String,
+  pub scopes: Vec<String>,
+  pub endpoints: GoogleEndpoints,
+}
+
+#[derive(Deserialize)]
+pub struct GoogleEndpoints {
+  pub sheets_read_url: String,
+  pub spreadsheets_sheets_url: String,
+  pub drive_files_url: String,
+  pub openid_url: String,
 }
 
 fn init() -> Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,7 +35,8 @@ pub struct OAuth {
   pub auth_url: String,
   pub token_url: String,
   pub auth_redirect_url: String,
-  pub scope: String,
+  pub drive_scope: String,
+  pub sheets_scope: String,
 }
 
 fn init() -> Config {

--- a/src/graphql/schema/blocks/integration_block.rs
+++ b/src/graphql/schema/blocks/integration_block.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 
 use crate::graphql::context::GQLContext;
 use crate::graphql::schema::block::{Block, BlockParts, BlockTypes, GQLBlocks, NewBlock};
-use crate::graphql::schema::integration::{Integration, IntegrationData};
+use crate::graphql::schema::integration::Integration;
 use crate::graphql::schema::{Mutation, Query};
 use crate::services::db::block_service::{create_integration_block, get_block};
 use crate::services::db::integration_service::get_integration;

--- a/src/graphql/schema/cell.rs
+++ b/src/graphql/schema/cell.rs
@@ -12,7 +12,7 @@ use super::cells::empty_cell::EmptyCell;
 use super::cells::google_sheets_cell::GoogleSheetsCell;
 use super::cells::owner_text_cell::OwnerTextCell;
 use super::dimension::Dimension;
-use super::integration::{Integration, IntegrationData};
+use super::integration::Integration;
 use super::Mutation;
 use super::Query;
 

--- a/src/graphql/schema/cells/google_sheets_cell.rs
+++ b/src/graphql/schema/cells/google_sheets_cell.rs
@@ -10,5 +10,5 @@ pub struct GoogleSheetsCell {
 
   pub col_dimension: Uuid,
 
-  pub value: String,
+  // pub value: String,
 }

--- a/src/graphql/schema/cells/google_sheets_cell.rs
+++ b/src/graphql/schema/cells/google_sheets_cell.rs
@@ -6,9 +6,9 @@ pub struct GoogleSheetsCell {
   // TODO: figure out what values should be stored in this cell
   pub integration_id: Uuid,
 
-  pub row_dimension: Uuid,
+  // pub row_dimension: Uuid,
 
-  pub col_dimension: Uuid,
+  // pub col_dimension: Uuid,
 
-  // pub value: String,
+  pub value: String,
 }

--- a/src/graphql/schema/dimension.rs
+++ b/src/graphql/schema/dimension.rs
@@ -14,6 +14,7 @@ use super::Mutation;
 use super::Query;
 
 use super::dimensions::google_sheets_column_dimension::GoogleSheetsColumnDimension;
+use super::dimensions::google_sheets_dimension::GoogleSheetsDimension;
 use super::dimensions::google_sheets_row_dimension::GoogleSheetsRowDimension;
 use super::dimensions::{
   basic_table_column_dimension::BasicTableColumnDimension,
@@ -47,6 +48,10 @@ pub enum DimensionTypes {
   #[graphql(name = "GoogleSheetsColumn")]
   GoogleSheetsColumn,
 
+  #[strum(serialize = "GoogleSheets")]
+  #[graphql(name = "GoogleSheets")]
+  GoogleSheets,
+
   #[strum(serialize = "Empty")]
   #[graphql(name = "Empty")]
   Empty,
@@ -60,6 +65,7 @@ pub enum GQLDimensions {
   OwnerText(OwnerTextDimension),
   GoogleSheetsRow(GoogleSheetsRowDimension),
   GoogleSheetsColumn(GoogleSheetsColumnDimension),
+  GoogleSheets(GoogleSheetsDimension),
   Empty(EmptyDimension),
 }
 
@@ -123,6 +129,11 @@ impl From<DBDimension> for Dimension {
         let d: GoogleSheetsColumnDimension = serde_json::from_value(db_dimension.dimension_data)
           .expect("Can't deserialize GoogleSheetsColumnDimension");
         GQLDimensions::GoogleSheetsColumn(d)
+      }
+      "GoogleSheets" => {
+        let d: GoogleSheetsDimension = serde_json::from_value(db_dimension.dimension_data)
+          .expect("Can't deserialize GoogleSheetsDimension");
+        GQLDimensions::GoogleSheets(d)
       }
       "Empty" => {
         let d: EmptyDimension = serde_json::from_value(db_dimension.dimension_data)

--- a/src/graphql/schema/dimensions/google_sheets_dimension.rs
+++ b/src/graphql/schema/dimensions/google_sheets_dimension.rs
@@ -1,0 +1,6 @@
+use juniper::GraphQLObject;
+
+#[derive(GraphQLObject, Clone, Debug, Serialize, Deserialize)]
+pub struct GoogleSheetsDimension {
+  pub empty: bool,
+}

--- a/src/graphql/schema/dimensions/mod.rs
+++ b/src/graphql/schema/dimensions/mod.rs
@@ -5,3 +5,4 @@ pub mod basic_table_row_dimension;
 pub mod basic_table_column_dimension;
 pub mod google_sheets_row_dimension;
 pub mod google_sheets_column_dimension;
+pub mod google_sheets_dimension;

--- a/src/graphql/schema/integration.rs
+++ b/src/graphql/schema/integration.rs
@@ -7,7 +7,6 @@ use strum_macros::{Display, EnumString};
 use uuid::Uuid;
 
 use crate::graphql::context::GQLContext;
-use crate::services::db::dimension_service::{create_dimensions, DBDimension, DBNewDimension};
 use crate::services::db::integration_service::{
   create_integration, get_integration, get_integrations, DBIntegration, DBNewIntegration,
 };
@@ -48,41 +47,6 @@ pub struct Integration {
 
   pub updated_by: Uuid,
 }
-
-// impl Integration {
-// TODO: Allow for fetching of >1 cells (possibly return Vec<Vec<String>> instead)
-// pub async fn fetch_value(&self, dims: Vec<String>) -> FieldResult<String> {
-// match &self.integration_data {
-//   IntegrationData::GoogleSheets(data) => {
-//     let mut dims = dims.into_iter();
-//     let row_dim = dims.next().expect("Row dimension to query not found");
-//     let col_dim = dims.next().expect("Column dimension to query not found");
-
-//     let row_idx = data
-//       .row_dimensions
-//       .iter()
-//       .position(|s| s == &row_dim)
-//       .expect(&format!("Unable to find row dimension: {}", row_dim));
-
-//     let col_idx = data
-//       .col_dimensions
-//       .iter()
-//       .position(|s| s == &col_dim)
-//       .expect(&format!("Unable to find column dimension: {}", col_dim));
-
-//     let sheets_obj = fetch_sheets_value(
-//       data.sheet_url.clone(),
-//       data.sheet_name.clone(),
-//       Some(format!("R{}C{}", row_idx + 2, col_idx + 1)),
-//     )
-//     .await;
-
-//     Ok(sheets_obj.value_ranges[0].values[0][0].clone())
-//   }
-// }
-//     Ok(String::from("stubbed out"))
-//   }
-// }
 
 impl From<DBIntegration> for Integration {
   fn from(db_integration: DBIntegration) -> Self {

--- a/src/graphql/schema/integration.rs
+++ b/src/graphql/schema/integration.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use juniper::{
   graphql_object, FieldError, FieldResult, GraphQLEnum, GraphQLInputObject, GraphQLObject,
   GraphQLUnion,
@@ -22,11 +23,11 @@ pub enum IntegrationTypes {
 
 // TODO: figure out how to pass this as GraphQLInput.
 // Note that the spec says "Unions are never valid inputs" (https://spec.graphql.org/June2018/#sec-Unions)
-#[derive(GraphQLUnion, Clone, Debug, Deserialize, Serialize)]
-#[graphql(Context = GQLContext)]
-pub enum IntegrationData {
-  GoogleSheets(GoogleSheetsIntegration),
-}
+// #[derive(GraphQLUnion, Clone, Debug, Deserialize, Serialize)]
+// #[graphql(Context = GQLContext)]
+// pub enum IntegrationData {
+//   GoogleSheets(GoogleSheetsIntegration),
+// }
 
 #[derive(GraphQLObject, Clone, Debug, Deserialize, Serialize)]
 #[graphql(Context = GQLContext)]
@@ -39,48 +40,54 @@ pub struct Integration {
 
   pub integration_type: IntegrationTypes,
 
-  pub integration_data: IntegrationData,
+  pub created_at: DateTime<Utc>,
+
+  pub created_by: Uuid,
+
+  pub updated_at: DateTime<Utc>,
+
+  pub updated_by: Uuid,
 }
 
-impl Integration {
-  // TODO: Allow for fetching of >1 cells (possibly return Vec<Vec<String>> instead)
-  pub async fn fetch_value(&self, dims: Vec<String>) -> FieldResult<String> {
-    // match &self.integration_data {
-    //   IntegrationData::GoogleSheets(data) => {
-    //     let mut dims = dims.into_iter();
-    //     let row_dim = dims.next().expect("Row dimension to query not found");
-    //     let col_dim = dims.next().expect("Column dimension to query not found");
+// impl Integration {
+// TODO: Allow for fetching of >1 cells (possibly return Vec<Vec<String>> instead)
+// pub async fn fetch_value(&self, dims: Vec<String>) -> FieldResult<String> {
+// match &self.integration_data {
+//   IntegrationData::GoogleSheets(data) => {
+//     let mut dims = dims.into_iter();
+//     let row_dim = dims.next().expect("Row dimension to query not found");
+//     let col_dim = dims.next().expect("Column dimension to query not found");
 
-    //     let row_idx = data
-    //       .row_dimensions
-    //       .iter()
-    //       .position(|s| s == &row_dim)
-    //       .expect(&format!("Unable to find row dimension: {}", row_dim));
+//     let row_idx = data
+//       .row_dimensions
+//       .iter()
+//       .position(|s| s == &row_dim)
+//       .expect(&format!("Unable to find row dimension: {}", row_dim));
 
-    //     let col_idx = data
-    //       .col_dimensions
-    //       .iter()
-    //       .position(|s| s == &col_dim)
-    //       .expect(&format!("Unable to find column dimension: {}", col_dim));
+//     let col_idx = data
+//       .col_dimensions
+//       .iter()
+//       .position(|s| s == &col_dim)
+//       .expect(&format!("Unable to find column dimension: {}", col_dim));
 
-    //     let sheets_obj = fetch_sheets_value(
-    //       data.sheet_url.clone(),
-    //       data.sheet_name.clone(),
-    //       Some(format!("R{}C{}", row_idx + 2, col_idx + 1)),
-    //     )
-    //     .await;
+//     let sheets_obj = fetch_sheets_value(
+//       data.sheet_url.clone(),
+//       data.sheet_name.clone(),
+//       Some(format!("R{}C{}", row_idx + 2, col_idx + 1)),
+//     )
+//     .await;
 
-    //     Ok(sheets_obj.value_ranges[0].values[0][0].clone())
-    //   }
-    // }
-    Ok(String::from("stubbed out"))
-  }
-}
+//     Ok(sheets_obj.value_ranges[0].values[0][0].clone())
+//   }
+// }
+//     Ok(String::from("stubbed out"))
+//   }
+// }
 
 impl From<DBIntegration> for Integration {
   fn from(db_integration: DBIntegration) -> Self {
-    let data = serde_json::from_value(db_integration.integration_data)
-      .expect("Unable to deserialize JSON integration_data.");
+    // let data = serde_json::from_value(db_integration.integration_data)
+    //   .expect("Unable to deserialize JSON integration_data.");
 
     Integration {
       portal_id: db_integration.portal_id,
@@ -90,7 +97,10 @@ impl From<DBIntegration> for Integration {
         .integration_type
         .parse()
         .expect("Unable to convert integration_type string to enum variant"),
-      integration_data: IntegrationData::GoogleSheets(data),
+      created_at: db_integration.created_at,
+      created_by: db_integration.created_by,
+      updated_at: db_integration.updated_at,
+      updated_by: db_integration.updated_by,
     }
   }
 }
@@ -102,9 +112,8 @@ pub struct NewIntegration {
   pub name: String,
 
   pub integration_type: IntegrationTypes,
-
   // JSON response from API call
-  pub integration_data: GoogleSheetsIntegrationInput,
+  // pub integration_data: GoogleSheetsIntegrationInput,
 }
 
 #[derive(GraphQLInputObject, Clone, Debug, Deserialize, Serialize)]
@@ -162,19 +171,19 @@ impl Mutation {
     //   .map(|row| row[0].clone())
     //   .collect();
     // let col_dimensions: Vec<String> = sheets_obj.value_ranges[0].values[0].clone();
-    let google_sheets_data = GoogleSheetsIntegration {
-      sheet_url: new_integration.integration_data.sheet_url,
-      sheet_name: new_integration.integration_data.sheet_name,
-      row_dimensions: vec![],
-      col_dimensions: vec![],
-    };
+    // let google_sheets_data = GoogleSheetsIntegration {
+    //   sheet_url: new_integration.integration_data.sheet_url,
+    //   sheet_name: new_integration.integration_data.sheet_name,
+    //   row_dimensions: vec![],
+    //   col_dimensions: vec![],
+    // };
 
     let db_new_integration = DBNewIntegration {
       portal_id: new_integration.portal_id,
       name: new_integration.name,
       integration_type: new_integration.integration_type.to_string(),
-      integration_data: serde_json::to_value(google_sheets_data)
-        .expect("Unable to serialize GoogleSheetsIntegration data into valid JSON format."),
+      // integration_data: serde_json::to_value(google_sheets_data)
+      //   .expect("Unable to serialize GoogleSheetsIntegration data into valid JSON format."),
     };
 
     create_integration(&ctx.pool, &ctx.auth0_user_id, db_new_integration)

--- a/src/graphql/schema/integrations/google_sheets.rs
+++ b/src/graphql/schema/integrations/google_sheets.rs
@@ -11,13 +11,22 @@ use crate::graphql::schema::{Mutation, Query};
 use crate::services::db::cell_service::{create_cell, DBNewCell};
 use crate::services::db::dimension_service::{create_dimension, DBDimension, DBNewDimension};
 use crate::services::db::integration_service::{create_integration, get_integration};
-use crate::services::google_sheets_service::{
-  GoogleSheetsSheetDimensions, GoogleSheetsSpreadsheet,
-};
 
 #[derive(GraphQLObject, Debug, Serialize, Deserialize)]
 pub struct GoogleSheetsRedirectURI {
   pub redirect_uri: String,
+}
+
+#[derive(GraphQLObject, Debug, Deserialize)]
+pub struct GoogleSheetsSpreadsheet {
+  pub id: String,
+  pub name: String,
+}
+
+#[derive(GraphQLObject, Debug, Deserialize)]
+pub struct GoogleSheetsSheetDimensions {
+  pub row_dimensions: Vec<String>,
+  pub col_dimensions: Vec<String>,
 }
 
 #[derive(GraphQLInputObject, Debug, Serialize, Deserialize)]
@@ -31,8 +40,9 @@ impl Query {
   ) -> FieldResult<GoogleSheetsRedirectURI> {
     let config = config::server_config();
 
+    let scopes = config.oauth.scopes.join("+");
     let redirect_uri = format!(
-      "{}?client_id={}&redirect_uri={}&response_type=code&scope={}+{}+openid+email&prompt=consent&access_type=offline&state={}",
+      "{}?client_id={}&redirect_uri={}&response_type=code&scope={}&prompt=consent&access_type=offline&state={}",
       config
         .oauth
         .auth_url,
@@ -42,8 +52,7 @@ impl Query {
       config
         .oauth
         .auth_redirect_url,
-      config.oauth.sheets_scope,
-      config.oauth.drive_scope,
+      scopes,
       state
     );
 

--- a/src/graphql/schema/integrations/google_sheets.rs
+++ b/src/graphql/schema/integrations/google_sheets.rs
@@ -1,8 +1,11 @@
 use juniper::{FieldResult, GraphQLInputObject, GraphQLObject};
+use uuid::Uuid;
 
 use crate::graphql::context::GQLContext;
 use crate::config;
+use crate::graphql::schema::integration::{IntegrationTypes, NewIntegration};
 use crate::graphql::schema::{Query, Mutation};
+use crate::services::db::integration_service::create_integration;
 
 #[derive(GraphQLObject, Debug, Serialize, Deserialize)]
 pub struct GoogleSheetsRedirectURI {
@@ -38,12 +41,28 @@ impl Query {
 }
 
 impl Mutation {
-  pub async fn authorize_google_sheets_impl(ctx: &GQLContext, auth: GoogleSheetsAuthorization) -> FieldResult<bool> {
+  pub async fn authorize_google_sheets_impl(
+    ctx: &GQLContext, 
+    portal_id: Uuid, 
+    auth: GoogleSheetsAuthorization
+  ) -> FieldResult<bool> {
     let mut gs = ctx.google_sheets.lock().await;
 
     // This call needs to store the tokens that are retrieved. 
-    let _access_token = gs.exchange_code(auth.code).await?;
-
-    Ok(true)
+    let gsheets_token = gs.exchange_code(auth.code).await?;
+    // Integration should be created only after access_token successfully exchanged
+    let new_integration = NewIntegration {
+      portal_id,
+      // Sensible name -- email + hash?
+      name: "IntegrationTest".to_string(),
+      integration_type: IntegrationTypes::GoogleSheets,
+    };
+    let integration = create_integration(
+      &ctx.pool, 
+      ctx.auth0_user_id.as_str(),
+      new_integration.into()
+    ).await?;
+    
+    Ok(gs.store_token(integration.id, gsheets_token).await?)
   }
 }

--- a/src/graphql/schema/integrations/google_sheets.rs
+++ b/src/graphql/schema/integrations/google_sheets.rs
@@ -32,7 +32,7 @@ impl Query {
     let config = config::server_config();
 
     let redirect_uri = format!(
-      "{}?client_id={}&redirect_uri={}&response_type=code&scope={}+{}&prompt=consent&access_type=offline&state={}",
+      "{}?client_id={}&redirect_uri={}&response_type=code&scope={}+{}+openid+email&prompt=consent&access_type=offline&state={}",
       config
         .oauth
         .auth_url,
@@ -137,11 +137,12 @@ impl Mutation {
 
     // This call needs to store the tokens that are retrieved.
     let gsheets_token = gs.exchange_code(auth.code).await?;
+    let user_email = gs.get_user_email(&gsheets_token).await?;
     // Integration should be created only after access_token successfully exchanged
     let new_integration = NewIntegration {
       portal_id,
       // Sensible name -- email + hash?
-      name: "IntegrationTest".to_string(),
+      name: user_email,
       integration_type: IntegrationTypes::GoogleSheets,
     };
     let integration = create_integration(

--- a/src/graphql/schema/integrations/google_sheets.rs
+++ b/src/graphql/schema/integrations/google_sheets.rs
@@ -3,10 +3,17 @@ use uuid::Uuid;
 
 use crate::config;
 use crate::graphql::context::GQLContext;
-use crate::graphql::schema::integration::{IntegrationTypes, NewIntegration};
+use crate::graphql::schema::cells::basic_text_cell::BasicTextCell;
+use crate::graphql::schema::dimension::Dimension;
+use crate::graphql::schema::dimensions::google_sheets_dimension::GoogleSheetsDimension;
+use crate::graphql::schema::integration::{Integration, IntegrationTypes, NewIntegration};
 use crate::graphql::schema::{Mutation, Query};
-use crate::services::db::integration_service::create_integration;
-use crate::services::google_sheets_service::{GoogleSheetsSheetDimensions, GoogleSheetsSpreadsheet, GoogleSheetsToken};
+use crate::services::db::cell_service::{create_cell, DBNewCell};
+use crate::services::db::dimension_service::{create_dimension, DBDimension, DBNewDimension};
+use crate::services::db::integration_service::{create_integration, get_integration};
+use crate::services::google_sheets_service::{
+  GoogleSheetsSheetDimensions, GoogleSheetsSpreadsheet,
+};
 
 #[derive(GraphQLObject, Debug, Serialize, Deserialize)]
 pub struct GoogleSheetsRedirectURI {
@@ -19,7 +26,9 @@ pub struct GoogleSheetsAuthorization {
 }
 
 impl Query {
-  pub async fn google_sheets_redirect_uri_impl(state: String) -> FieldResult<GoogleSheetsRedirectURI> {
+  pub async fn google_sheets_redirect_uri_impl(
+    state: String,
+  ) -> FieldResult<GoogleSheetsRedirectURI> {
     let config = config::server_config();
 
     let redirect_uri = format!(
@@ -71,33 +80,62 @@ impl Query {
   ) -> FieldResult<GoogleSheetsSheetDimensions> {
     let gs = ctx.google_sheets.lock().await;
 
-    Ok(gs.fetch_sheet_dimensions(integration_id, spreadsheet_id, sheet_name).await?)
+    Ok(
+      gs.fetch_sheet_dimensions(integration_id, spreadsheet_id, sheet_name)
+        .await?,
+    )
   }
-  
-  // Needed? Or should only be handled by googlesheetscell (tho not likely as a embedded resolver)
+
+  // TODO: For now, returns GoogleSheetsDimension stored by the created GoogleSheetsCell
   pub async fn google_sheets_fetch_sheet_values_impl(
     ctx: &GQLContext,
     integration_id: Uuid,
     spreadsheet_id: String,
     sheet_name: String,
     range: String,
-  ) -> FieldResult<String> {
+  ) -> FieldResult<Dimension> {
     let gs = ctx.google_sheets.lock().await;
     let sheet_range = format!("{}!{}", sheet_name, range);
 
-    Ok(gs.fetch_sheet_value(integration_id, spreadsheet_id, sheet_range).await?)
+    let value = gs
+      .fetch_sheet_value(integration_id, spreadsheet_id, sheet_range)
+      .await?;
+
+    let integration: Integration = get_integration(&ctx.pool, integration_id).await?.into();
+
+    let google_sheets_dim = DBNewDimension {
+      portal_id: integration.portal_id,
+      name: "VendorGoogleSheetsDimension".to_string(),
+      dimension_type: "GoogleSheets".to_string(),
+      dimension_data: serde_json::to_value(GoogleSheetsDimension { empty: true })
+        .expect("Unable to serialize GoogleSheetsDimension"),
+    };
+    let db_dim: DBDimension =
+      create_dimension(&ctx.pool, ctx.auth0_user_id.as_str(), google_sheets_dim).await?;
+
+    let new_cell = DBNewCell {
+      portal_id: integration.portal_id,
+      dimensions: vec![db_dim.id],
+      cell_type: "BasicText".to_string(),
+      cell_data: serde_json::to_value(BasicTextCell { text: value })
+        .expect("Unable to serialize BasicTextCell"),
+    };
+
+    create_cell(&ctx.pool, ctx.auth0_user_id.as_str(), new_cell).await?;
+
+    Ok(db_dim.into())
   }
 }
 
 impl Mutation {
   pub async fn authorize_google_sheets_impl(
-    ctx: &GQLContext, 
-    portal_id: Uuid, 
-    auth: GoogleSheetsAuthorization
+    ctx: &GQLContext,
+    portal_id: Uuid,
+    auth: GoogleSheetsAuthorization,
   ) -> FieldResult<bool> {
     let mut gs = ctx.google_sheets.lock().await;
 
-    // This call needs to store the tokens that are retrieved. 
+    // This call needs to store the tokens that are retrieved.
     let gsheets_token = gs.exchange_code(auth.code).await?;
     // Integration should be created only after access_token successfully exchanged
     let new_integration = NewIntegration {
@@ -107,10 +145,11 @@ impl Mutation {
       integration_type: IntegrationTypes::GoogleSheets,
     };
     let integration = create_integration(
-      &ctx.pool, 
+      &ctx.pool,
       ctx.auth0_user_id.as_str(),
-      new_integration.into()
-    ).await?;
+      new_integration.into(),
+    )
+    .await?;
 
     Ok(gs.store_token(integration.id, gsheets_token).await?)
   }

--- a/src/graphql/schema/mod.rs
+++ b/src/graphql/schema/mod.rs
@@ -319,8 +319,12 @@ impl Mutation {
 
   // Specific Integrations
 
-  async fn authorize_google_sheets(ctx: &GQLContext, auth: GoogleSheetsAuthorization) -> FieldResult<bool> {
-    Mutation::authorize_google_sheets_impl(ctx, auth).await
+  async fn authorize_google_sheets(
+    ctx: &GQLContext,
+    portal_id: Uuid,
+    auth: GoogleSheetsAuthorization,
+  ) -> FieldResult<bool> {
+    Mutation::authorize_google_sheets_impl(ctx, portal_id, auth).await
   }
 }
 

--- a/src/graphql/schema/mod.rs
+++ b/src/graphql/schema/mod.rs
@@ -1,4 +1,4 @@
-use juniper::{EmptySubscription, FieldResult, RootNode, graphql_object};
+use juniper::{graphql_object, EmptySubscription, FieldResult, RootNode};
 use uuid::Uuid;
 
 pub mod block;
@@ -16,14 +16,12 @@ pub mod role;
 pub mod structure;
 pub mod user;
 
-use crate::services::google_sheets_service::{
-  GoogleSheetsSheetDimensions, GoogleSheetsSpreadsheet,
+use self::integrations::google_sheets::{
+  GoogleSheetsAuthorization, GoogleSheetsSheetDimensions, GoogleSheetsSpreadsheet,
 };
 
-use self::integrations::google_sheets::GoogleSheetsAuthorization;
-
 use super::context::GQLContext;
-use block::{Block, NewBlock, BlockParts, UpdateBlock};
+use block::{Block, BlockParts, NewBlock, UpdateBlock};
 use blocks::{
   basic_table_block::NewBasicTableBlock, integration_block::NewIntegrationBlock,
   owner_text_block::NewOwnerTextBlock, vendor_text_block::NewVendorTextBlock,
@@ -336,7 +334,10 @@ impl Mutation {
 
   // Dimension
 
-  async fn create_dimension(ctx: &GQLContext, new_dimension: NewDimension) -> FieldResult<Dimension> {
+  async fn create_dimension(
+    ctx: &GQLContext,
+    new_dimension: NewDimension,
+  ) -> FieldResult<Dimension> {
     Mutation::create_dimension_impl(ctx, new_dimension).await
   }
 

--- a/src/graphql/schema/mod.rs
+++ b/src/graphql/schema/mod.rs
@@ -202,13 +202,14 @@ impl Query {
     .await
   }
 
+  // TODO: this really shouldn't be a query, need to decouple
   async fn google_sheets_fetch_sheet_value(
     ctx: &GQLContext,
     integration_id: Uuid,
     spreadsheet_id: String,
     sheet_name: String,
     range: String,
-  ) -> FieldResult<String> {
+  ) -> FieldResult<Dimension> {
     Query::google_sheets_fetch_sheet_values_impl(
       ctx,
       integration_id,

--- a/src/graphql/schema/mod.rs
+++ b/src/graphql/schema/mod.rs
@@ -16,6 +16,10 @@ pub mod role;
 pub mod structure;
 pub mod user;
 
+use crate::services::google_sheets_service::{
+  GoogleSheetsSheetDimensions, GoogleSheetsSpreadsheet,
+};
+
 use self::integrations::google_sheets::GoogleSheetsAuthorization;
 
 use super::context::GQLContext;
@@ -26,14 +30,14 @@ use blocks::{
 };
 use cell::{Cell, NewCell, UpdateCell};
 use dimension::{Dimension, NewDimension};
+use integration::{Integration, NewIntegration};
+use integrations::google_sheets::GoogleSheetsRedirectURI;
 use org::{NewOrg, Org};
-use portal::{Portal, PortalParts, NewPortal, PortalInviteParams, UpdatePortal};
+use portal::{NewPortal, Portal, PortalInviteParams, PortalParts, UpdatePortal};
 use portalview::{NewPortalView, PortalView, PortalViewParts};
 use role::{NewRole, Role};
 use structure::{Structure, UpdateStructure};
 use user::{NewUser, UpdateUser, User};
-use integration::{Integration, NewIntegration};
-use integrations::google_sheets::GoogleSheetsRedirectURI;
 
 pub type Schema = RootNode<'static, Query, Mutation, EmptySubscription<GQLContext>>;
 pub struct Query;
@@ -165,6 +169,54 @@ impl Query {
 
   async fn google_sheets_redirect_uri(state: String) -> FieldResult<GoogleSheetsRedirectURI> {
     Query::google_sheets_redirect_uri_impl(state).await
+  }
+
+  async fn google_sheets_list_spreadsheets(
+    ctx: &GQLContext,
+    integration_id: Uuid,
+  ) -> FieldResult<Vec<GoogleSheetsSpreadsheet>> {
+    Query::google_sheets_list_spreadsheets_impl(ctx, integration_id).await
+  }
+
+  async fn google_sheets_list_spreadsheets_sheets_names(
+    ctx: &GQLContext,
+    integration_id: Uuid,
+    spreadsheet_id: String,
+  ) -> FieldResult<Vec<String>> {
+    Query::google_sheets_list_spreadsheets_sheets_names_impl(ctx, integration_id, spreadsheet_id)
+      .await
+  }
+
+  async fn google_sheets_fetch_sheet_dimensions(
+    ctx: &GQLContext,
+    integration_id: Uuid,
+    spreadsheet_id: String,
+    sheet_name: String,
+  ) -> FieldResult<GoogleSheetsSheetDimensions> {
+    Query::google_sheets_fetch_sheet_dimensions_impl(
+      ctx,
+      integration_id,
+      spreadsheet_id,
+      sheet_name,
+    )
+    .await
+  }
+
+  async fn google_sheets_fetch_sheet_value(
+    ctx: &GQLContext,
+    integration_id: Uuid,
+    spreadsheet_id: String,
+    sheet_name: String,
+    range: String,
+  ) -> FieldResult<String> {
+    Query::google_sheets_fetch_sheet_values_impl(
+      ctx,
+      integration_id,
+      spreadsheet_id,
+      sheet_name,
+      range,
+    )
+    .await
   }
 }
 

--- a/src/services/db/block_service.rs
+++ b/src/services/db/block_service.rs
@@ -644,15 +644,15 @@ pub async fn create_integration_block(
     integration_id: new_integration_block.integration_id,
     row_dimension: db_dimensions[0].id,
     col_dimension: db_dimensions[1].id,
-    value: integration
-      .fetch_value(
-        db_dimensions
-          .iter()
-          .map(|db_dim| db_dim.name.clone())
-          .collect(),
-      )
-      .await
-      .unwrap(),
+    // value: integration
+    //   .fetch_value(
+    //     db_dimensions
+    //       .iter()
+    //       .map(|db_dim| db_dim.name.clone())
+    //       .collect(),
+    //   )
+    //   .await
+    //   .unwrap(),
   };
 
   let new_cell = DBNewCell {

--- a/src/services/db/block_service.rs
+++ b/src/services/db/block_service.rs
@@ -642,8 +642,9 @@ pub async fn create_integration_block(
     .into();
   let google_sheet_cell = GoogleSheetsCell {
     integration_id: new_integration_block.integration_id,
-    row_dimension: db_dimensions[0].id,
-    col_dimension: db_dimensions[1].id,
+    value: "".to_string(),
+    // row_dimension: db_dimensions[0].id,
+    // col_dimension: db_dimensions[1].id,
     // value: integration
     //   .fetch_value(
     //     db_dimensions

--- a/src/services/db/dimension_service.rs
+++ b/src/services/db/dimension_service.rs
@@ -4,6 +4,7 @@ use crate::graphql::schema::{
     basic_table_column_dimension::BasicTableColumnDimension,
     basic_table_row_dimension::BasicTableRowDimension, empty_dimension::EmptyDimension,
     google_sheets_column_dimension::GoogleSheetsColumnDimension,
+    google_sheets_dimension::GoogleSheetsDimension,
     google_sheets_row_dimension::GoogleSheetsRowDimension,
     owner_text_dimension::OwnerTextDimension, portal_member_dimension::PortalMemberDimension,
   },
@@ -91,6 +92,13 @@ impl From<NewDimension> for DBNewDimension {
           .expect("Unable to parse GoogleSheetsColumn data");
         serde_json::to_value(dim)
           .expect("Unable to convert GoogleSheetsColumn back to serde_json::Value")
+      }
+      // Placeholder Dimension for now to fit into VendorText
+      DimensionTypes::GoogleSheets => {
+        let dim: GoogleSheetsDimension = serde_json::from_str(&new_dim.dimension_data)
+          .expect("Unable to parse GoogleSheetsDimension data");
+        serde_json::to_value(dim)
+          .expect("Unable to convert GoogleSheetsDimension back to serde_json::Value")
       }
       DimensionTypes::Empty => {
         let dim: EmptyDimension = serde_json::from_str(&new_dim.dimension_data)

--- a/src/services/db/integration_service.rs
+++ b/src/services/db/integration_service.rs
@@ -36,10 +36,9 @@ pub struct DBNewIntegration {
   pub name: String,
 
   pub integration_type: String,
-
   // TODO: replace with json string to insert into Postgres jsonb format
   // JSON response from API call
-  pub integration_data: serde_json::Value,
+  // pub integration_data: serde_json::Value,
 }
 
 impl From<NewIntegration> for DBNewIntegration {
@@ -48,8 +47,6 @@ impl From<NewIntegration> for DBNewIntegration {
       portal_id: new_integration.portal_id,
       name: new_integration.name,
       integration_type: new_integration.integration_type.to_string(),
-      integration_data: serde_json::to_value(new_integration.integration_data)
-        .expect("Unable to serialize input integration_data into valid JSON format"),
     }
   }
 }
@@ -91,15 +88,14 @@ pub async fn create_integration<'e>(
     DBIntegration,
     r#"
     with _user as (select * from users where auth0id = $1)
-    insert into integrations (name, portal_id, integration_type, integration_data, created_by, updated_by)
-    values ($2, $3, $4, $5, (select id from _user), (select id from _user))
+    insert into integrations (name, portal_id, integration_type, created_by, updated_by)
+    values ($2, $3, $4, (select id from _user), (select id from _user))
     returning *;
     "#,
     auth0_user_id,
     new_integration.name,
     new_integration.portal_id,
     new_integration.integration_type,
-    new_integration.integration_data,
   )
   .fetch_one(pool)
   .await


### PR DESCRIPTION
# Overview

There are two main changes this PR brings, both of which support the changes made on the web client: 

1. Completion of the Google OAuth authorization flow
- This is mainly achieved through `GoogleSheetsService`, which now stores a `HashMap<Uuid, GoogleSheetsToken>` mapping an `Integration` UUID to an access token. For now, the concept of an `Integration` has been rebranded to that of a single "Connection" between a user and Google. Much of the logic for the exchanging of the access token has been brought here:
- https://github.com/Torus-Portals/portals-backend/blob/976cbafc36ce6d2acbf23dae33081d05ab35aa3d/src/services/google_sheets_service.rs#L177-L243

2. GQL routes/resolvers to support the Integration options presented on the front end.
- The resolvers by nature are reasonably straightforward -- each of them simply makes a call to `GoogleSheetsService` (naturally as well, since it holds the access tokens), which then handles the API calls to Google to retrieve the list of spreadsheets, sheet names, etc.
- The services making the calls can be found here:
- https://github.com/Torus-Portals/portals-backend/blob/976cbafc36ce6d2acbf23dae33081d05ab35aa3d/src/services/google_sheets_service.rs#L260-L383

# Further Changes

- Add refresh token logic (some Rust subtleties to wrangle with for now, to do with mutating a stored `Hashmap`)
- Decouple the `googleSheetsFetchSheetValue` Query (it perhaps shouldn't be a Query, since it creates a new Dimension + Cell for populating in the `VendorTextBlock`). Still thinking of how to achieve this simply.